### PR TITLE
Move details of AVS specific instruction steps from getting started guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.order
 AlexaClientSDKConfig*
 time_taken.txt
+.*.swp

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ You will need:
 You will also need an Amazon Developer account: https://developer.amazon.com
 
 ## Hardware setup
-Setup your hardware by following the **Hardware Setup** at: https://xmos.com/vocalfusion-stereo-avs
+Setup your hardware by following the **Hardware Setup** at: https://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-hardware-setup-guide
 
 ## AVS SDK installation and Raspberry Pi audio setup
-Full instructions to install the AVS SDK on to a Raspberry Pi and configure the audio to use the **xCORE VocalFusion Stereo 4-Mic Kit for AVS** are detailed in the **Getting Started Guide** available from: https://xmos.com/vocalfusion-stereo-avs.
+Full instructions to install the AVS SDK on to a Raspberry Pi and configure the audio to use the **xCORE VocalFusion Stereo 4-Mic Kit for AVS** are detailed in the **Getting Started Guide** available from: http://www.xmos.com/published/vocalfusion-stereo-dev-kit-avs-quick-start-guide.
 
 Brief instructions and additional notes are below:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,9 @@ The **Getting Started Guide** available from http://www.xmos.com/published/vocal
 
 4. Run the installation script by entering `./auto_install.sh`. Read and accept the AVS Device SDK license agreement.
 
-5. You will be prompted enter your Alexa device details and asked whether you want the Sample App to run automatically when the Raspberry Pi boots.
+5. You will be prompted enter your Alexa device details and asked whether you want the Sample App to run automatically when the Raspberry Pi boots. Your Alexa device details are the *ProductID*, the *ClientID* and *ClientSecret* keys as generated in the previous step. You will also be prompted to enter a serial number and define your location.
 
-6. Read and accept the Sensory license agreement.
-Wait for the script to complete the installation. This can take some time.
+6. Read and accept the Sensory license agreement. Wait for the script to complete the installation. The script is configuring the Raspberry Pi audio system, downloading and updating dependencies, building and configuring the AVS Device SDK. It takes around 30 minutes to complete.
 
 7. As a final step, the script will open http://localhost:3000 in a browser on the Raspberry Pi. Enter your Amazon Developer credentials and close the browser window when prompted. (You won't have to do this if you already have a valid configuration file.)  
 If you see a `400 Bad Request - HTTP` error it may be necessary to add http:// URLs to your device origins and return fields. To do this, go to your amazon developer AVS home page (https://developer.amazon.com/avs/home.html) and from `My products` select `manage` and then `security profile`. Now add http://localhost:3000 to the `Allowed origins` and http://localhost:3000/authresponse to the `Allowed return URLs`. Now refresh the browser window with the original error.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The **Getting Started Guide** available from http://www.xmos.com/published/vocal
 ## Running the AVS SDK Sample App
 The automated installation script creates a number of aliases which can be used to execute the AVS Device SDK client, or run the unit tests:
 - `avsrun` to run the Sample App.
-- `avsauth` to re-authenticate your Alexa device details.
-- `avsunit` to run the unit tests.
-- `avssetup` to re-install the Sample App.
+- `avsauth` to re-authenticate your Alexa device details (invoke Amazon's `avs_auth.sh`).
+- `avsunit` to run the unit tests (invoke Amazon's `avs_test.sh`).
+- `avssetup` to re-install the Sample App (re-run XMOS modified `setup.sh`).
+
+## Using different Amazon details
+To change client and product ID, run `avssetup`. It will ask you to type in your IDs and invoke `avsauth` for you. As a result the SDK JSON file will be updated so subsequent `avsrun` can use the new details.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will also need an Amazon Developer account: https://developer.amazon.com
 Setup your hardware by following the **Hardware Setup** at: https://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-hardware-setup-guide
 
 ## AVS SDK installation and Raspberry Pi audio setup
-Full instructions to install the AVS SDK on to a Raspberry Pi and configure the audio to use the **xCORE VocalFusion Stereo 4-Mic Kit for AVS** are detailed in the **Getting Started Guide** available from: http://www.xmos.com/published/vocalfusion-stereo-dev-kit-avs-quick-start-guide.
+Full instructions to install the AVS SDK on to a Raspberry Pi and configure the audio to use the **xCORE VocalFusion Stereo 4-Mic Kit for AVS** are detailed in the **Getting Started Guide** available from: http://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-getting-started-guide
 
 Brief instructions and additional notes are below:
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,19 @@ You will also need an Amazon Developer account: https://developer.amazon.com
 Setup your hardware by following the **Hardware Setup** at: https://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-hardware-setup-guide
 
 ## AVS SDK installation and Raspberry Pi audio setup
-Full instructions to install the AVS SDK on to a Raspberry Pi and configure the audio to use the **xCORE VocalFusion Stereo 4-Mic Kit for AVS** are detailed in the **Getting Started Guide** available from: http://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-getting-started-guide
+The **Getting Started Guide** available from http://www.xmos.com/published/vocalfusion-stereo-dev-kit-for-amazon-avs-getting-started-guide details setup steps up until this point. What follows are setup steps specific to the AVS SDK.
 
-Brief instructions and additional notes are below:
+1. Install Raspbian (Stretch) on the Raspberry Pi as described in the Getting Started Guide.
 
-1. Install Raspbian (Stretch) on the Raspberry Pi.
+2. Clone the vocalfusion-stereo-avs-setup repository:
 
-2. Open a terminal on the Raspberry Pi and clone this repository:  
-`cd ~; git clone https://github.com/xmos/vocalfusion-stereo-avs-setup`
+   ```git clone https://github.com/xmos/vocalfusion-stereo-avs-setup```
 
-3. Create a new Alexa device by following: https://github.com/alexa/alexa-avs-sample-app/wiki/Create-Security-Profile  
-(Note: the *Allowed Origins* and *Allowed Return URLs* should use **http**, not https.)  
+3. Register Alexa with AVS by following http://github.com/alexa/alexa-avs-sample-app/wiki/Create-Security-Profile.
+
+   Note: The *Allowed Origins* and *Allowed Return URLs* should be entered as **http**, not https.
+
+   Note: It can be easier to configure your new Alexa device and Amazon developer account from a browser on your Raspberry Pi, as you can then easily copy the *ProductID*, *ClientID* and *ClientSecret* keys.
 
 4. Run the installation script: `source ~/vocalfusion-stereo-avs-setup/auto_install.sh`    
 Read and accept the AVS Device SDK license agreement.

--- a/README.md
+++ b/README.md
@@ -47,13 +47,12 @@ The **Getting Started Guide** available from http://www.xmos.com/published/vocal
 
 6. Read and accept the Sensory license agreement. Wait for the script to complete the installation. The script is configuring the Raspberry Pi audio system, downloading and updating dependencies, building and configuring the AVS Device SDK. It takes around 30 minutes to complete.
 
-7. As a final step, the script will open http://localhost:3000 in a browser on the Raspberry Pi. Enter your Amazon Developer credentials and close the browser window when prompted. (You won't have to do this if you already have a valid configuration file.)  
-If you see a `400 Bad Request - HTTP` error it may be necessary to add http:// URLs to your device origins and return fields. To do this, go to your amazon developer AVS home page (https://developer.amazon.com/avs/home.html) and from `My products` select `manage` and then `security profile`. Now add http://localhost:3000 to the `Allowed origins` and http://localhost:3000/authresponse to the `Allowed return URLs`. Now refresh the browser window with the original error.
+7. As a final step, the script will open http://localhost:3000 in a browser on the Raspberry Pi. Enter your Amazon Developer credentials and close the browser window when prompted. (You won't have to do this if you already have a valid configuration file.) If you see a `400 Bad Request - HTTP` error it may be necessary to add http:// URLs to your device origins and return fields. To do this, go to your amazon developer AVS home page (https://developer.amazon.com/avs/home.html) and from `My products` select `manage` and then `security profile`. Now add http://localhost:3000 to the `Allowed origins` and http://localhost:3000/authresponse to the `Allowed return URLs`. Now refresh the browser window with the original error.
 
 8. Enter `sudo reboot` to reboot the Raspberry Pi and complete the installation.
 
 ## Running the AVS SDK Sample App
-The following commands will be available to run from a terminal:
+The automated installation script creates a number of aliases which can be used to execute the AVS Device SDK client, or run the unit tests:
 - `avsrun` to run the Sample App.
 - `avsauth` to re-authenticate your Alexa device details.
 - `avsunit` to run the unit tests.

--- a/README.md
+++ b/README.md
@@ -37,12 +37,11 @@ The **Getting Started Guide** available from http://www.xmos.com/published/vocal
 
 3. Register Alexa with AVS by following http://github.com/alexa/alexa-avs-sample-app/wiki/Create-Security-Profile.
 
-   Note: The *Allowed Origins* and *Allowed Return URLs* should be entered as **http**, not https.
+   Note: The *Allowed Origins* and *Allowed Return URLs* should be entered as **http**, not **https**.
 
    Note: It can be easier to configure your new Alexa device and Amazon developer account from a browser on your Raspberry Pi, as you can then easily copy the *ProductID*, *ClientID* and *ClientSecret* keys.
 
-4. Run the installation script: `source ~/vocalfusion-stereo-avs-setup/auto_install.sh`    
-Read and accept the AVS Device SDK license agreement.
+4. Run the installation script by entering `./auto_install.sh`. Read and accept the AVS Device SDK license agreement.
 
 5. You will be prompted enter your Alexa device details and asked whether you want the Sample App to run automatically when the Raspberry Pi boots.
 


### PR DESCRIPTION
That way they will be in one place, GitHub